### PR TITLE
Update the SettingsGrid used on mobile to line up with navigation

### DIFF
--- a/src/components/SettingsGrid/SettingsGrid.tsx
+++ b/src/components/SettingsGrid/SettingsGrid.tsx
@@ -4,9 +4,11 @@ import Icon from '../Icon/Icon'
 import Button from '../Button/Button'
 import style from './SettingsGrid.module.css'
 import { useTheme } from '@/contexts/ThemeContext'
+import {useRouter} from 'next/navigation'
 
 export default function SettingsGrid() {
     const { mode, setThemeMode } = useTheme()
+    const router = useRouter()
 
     const toggleTheme = () => {
         setThemeMode(mode === 'light' ? 'dark' : 'light')
@@ -17,16 +19,22 @@ export default function SettingsGrid() {
             <div className={style.buttons}>
                 <div className={style.button}>
                     <Button onClick={toggleTheme}>
-                        <Icon src='/internal/moon.svg' size='2rem' />
+                        <Icon src='/internal/moon.svg' size='2rem'/>
                     </Button>
                 </div>
                 <div className={style.button}>
-                    <Button>
-                        <a href="https://marble.software/">
-                            <Icon src='/internal/marble.svg' size='2rem' />
-                        </a>
+                    <Button onClick={() => router.push('https://github.com/Ph0enixKM/Amber')}>
+                        <Icon src='/internal/gh.svg' size='2rem'/>
                     </Button>
                 </div>
+                {/* Uncomment when we are ready */}
+                {/* <div className={style.button}>
+                    <Button>
+                        <a href="https://marble.software/">
+                            <Icon src='/internal/marble.svg' size='2rem'/>
+                        </a>
+                    </Button>
+                </div> */}
             </div>
         </div>
     )


### PR DESCRIPTION
I had trouble finding the GitHub link on mobile and realized this had been missed in the recent update to add that link.

Also, once the [Readme update PR](https://github.com/Ph0enixKM/Docs-Builder/pull/14) is updated to reference `amber-lang.com` instead of `amber.marble.software` and has landed we may want to consider updating these GitHub links to point to the Docs-Builder repo instead of the Amber primary repo to make it easier for folks to find and contribute to the docs.