### PR TITLE
Document reservation of __ prefix for compiler

### DIFF
--- a/docs/basic_syntax/functions.md
+++ b/docs/basic_syntax/functions.md
@@ -99,3 +99,6 @@ echo groceries
 ```
 
 The behavior of this keyword is pretty similar to `&` in other C-like programming languages.
+
+## Reserved Prefix
+The Amber compiler reserves all identifiers starting with double underscore `__` in addition to keywords like `let`, `if`, etc.

--- a/docs/basic_syntax/variables.md
+++ b/docs/basic_syntax/variables.md
@@ -29,3 +29,5 @@ let result = 123
 let result = "Hello my friend"
 ```
 
+## Reserved Prefix
+The Amber compiler reserves all identifiers starting with double underscore `__` in addition to keywords like `let`, `if`, etc.


### PR DESCRIPTION
I believe this is accurate based off [of this code](https://github.com/Ph0enixKM/Amber/blob/30c9dfda06b268a1c3ed8f6efe6ac9a86e33999d/src/modules/variable/mod.rs#L63-L70)